### PR TITLE
chaging the base image and restricting the instances to GPU only

### DIFF
--- a/.github/ISSUE_TEMPLATE/request.yml
+++ b/.github/ISSUE_TEMPLATE/request.yml
@@ -16,7 +16,6 @@ body:
       label: Cloud Computing Instance Flavor
       description: Select the type of cloud-computing instance to create.
       options:
-        - m3.xl - General-purpose instance (32 CPUs, 125 GB RAM, no GPU)
         - g3.xl - GPU instance (32 CPUs, 125 GB RAM and A100 GPU)
     validations:
       required: true

--- a/.github/workflows/create-instance.yml
+++ b/.github/workflows/create-instance.yml
@@ -161,7 +161,7 @@ jobs:
             --security-group "default" \
             --security-group "exosphere" \
             --flavor $INSTANCE_FLAVOR \
-            --image "antsthings-vgl-gpu-image-Slicer-5.6.2" \
+            --image "GPU-rebuild-image-slicer562" \
             --key-name "jcfr" \
             --property "exoGuac={\"v\":1,\"ssh\":true,\"vnc\":true}" \
             --property "exoClientUuid=$exoClientUuid" \


### PR DESCRIPTION
JC
I have rebuild the image with newer kernel (6.5) as they suggests, which should mitigate some of the driver version updates. 
I also restricted the instance type to only GPU until we can figure out a way to make the CPU instances performant with the large polydata datasets (e.g., segmentations). 
Take a look and if all is good, merge.